### PR TITLE
set editor min height

### DIFF
--- a/src/app/javascript/styles/application.css
+++ b/src/app/javascript/styles/application.css
@@ -3,3 +3,7 @@
     border: 1px solid #eee;
     height: auto;
 }
+
+.CodeMirror-scroll {
+    min-height: 200px;
+}


### PR DESCRIPTION
UX improvement: set editor min-height so it's easy for people to notice the code editor

Old:
![image](https://user-images.githubusercontent.com/8272048/78145223-e821c180-7430-11ea-8760-f6ae39e76035.png)


New:
![image](https://user-images.githubusercontent.com/8272048/78145106-c294b800-7430-11ea-8f28-ec570b564da8.png)
